### PR TITLE
--no-livereload option, allowing user to disable autoreload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ program
   .version((packageInfo as any).version)
   .option('--jekyll-site <path>', 'Jekyll site path', resolvePath, process.cwd())
   .option('--port <port>', 'Livereload server port', '4000')
+  .option('--no-livereload', 'Disable Livereload', true)
   .parse(process.argv);
 
 run({
   jekyllPath: program.jekyllSite,
-  port: program.port
+  port: program.port,
+  livereload: program.livereload
 });

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -7,8 +7,8 @@ import * as gulp from 'gulp';
 import * as server from 'gulp-server-livereload';
 import * as yaml from 'js-yaml';
 
-export default function run(options: {jekyllPath: string, port: string}) {
-  const { jekyllPath, port } = options;
+export default function run(options: {jekyllPath: string, port: string, livereload: boolean}) {
+  const { jekyllPath, port, livereload } = options;
 
   function buildJekyll(): void {
     const cmd = 'bundle exec jekyll build --incremental && echo';
@@ -57,7 +57,7 @@ export default function run(options: {jekyllPath: string, port: string}) {
 
   gulp.task('server', ['build'], () => {
     gulp.src(`${jekyllPath}/_site`)
-      .pipe(server({ livereload: true, port }));
+      .pipe(server({ livereload, port }));
   });
 
   gulp.task('build', (done) => {


### PR DESCRIPTION
Addition of a new option `--no-livereload` which just disables livereload and changes nothing else.

I'm aware this may seem useless from first glance but for my use case it's a useful feature, I'll explain why:

We're using jekyll-dev to develop a jekyll theme reused accross multiple sites. This theme is referenced locally in multiple jekyll sites like so:

```
gem "our-reused-jekyll-theme", :path => "../our-reused-jekyll-theme"
```

Developing changes in the theme just using `bundle exec jekyll watch` is a real pain because it doesn't notice changes in the theme, only in the site itself. jekyll-dev however sets up gulp watches for the site **and** the theme so changes in the theme. Awesome!

So now in the theme we're developing an AJAXification feature, part of this replaces content in the `<body>` which ends up re-inserting the livereload script and that causes really odd behaviour. However, we still want to use jekyll-dev while working with this site, as the theme watch just by itself is incredibly helpful.

Hope that makes sense and is clear enough to justify accepting this PR :)
